### PR TITLE
use correct property for source sorting

### DIFF
--- a/projects/ngx-avatar/src/lib/avatar.component.ts
+++ b/projects/ngx-avatar/src/lib/avatar.component.ts
@@ -106,7 +106,7 @@ export class AvatarComponent implements OnChanges {
     public elementRef: ElementRef,
     public sourceFactory: SourceFactory,
     private avatarService: AvatarService
-  ) {}
+  ) { }
 
   // handle click event
   handleClickEvent(event: any) {
@@ -143,8 +143,8 @@ export class AvatarComponent implements OnChanges {
       // Order sources array by source priority
       this._sources.sort((leftSide, rightSide) => {
         return (
-          this.avatarService.getSourcePriority(leftSide.sourceId) -
-          this.avatarService.getSourcePriority(rightSide.sourceId)
+          this.avatarService.getSourcePriority(leftSide.sourceType)
+          - this.avatarService.getSourcePriority(rightSide.sourceType)
         );
       });
       // Host style


### PR DESCRIPTION
New PR on latest version of master to avoid merge conflict, cause merging #21, would be much more work.

Within the method `_initializeAvatar()` the sources are getting sorted, by the order given within the `avatarService`. The name of the service that is been used for the sorting is stored within the property `sourceType` and not `sourceId`.

This bug leads to various problems, cause the sources are not sorted in a specific way and especially if the `Initials: Source` comes first in the array the real picture from any different source will never show up.