### PR TITLE
Remove HTTP client module

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Once you have installed ngx-avatar, you can import it in your `AppModule`:
 ```typescript
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
+import { HttpClientModule } from '@angular/common/http';
 
 import { AppComponent } from './app.component';
 
@@ -62,6 +63,7 @@ import { AvatarModule } from 'ngx-avatar';
   ],
   imports: [
     BrowserModule,
+    HttpClientModule,
     // Specify AvatarModule as an import
     AvatarModule
   ],
@@ -70,6 +72,9 @@ import { AvatarModule } from 'ngx-avatar';
 })
 export class AppModule { }
 ```
+
+- `HttpClientModule` is mandatory in order to fetch the avatar from external sources (Gravatar, Google, ...).
+
 2. Start using it:
 
 Once the AvatarModule is imported, you can start using the component in your Angular application:

--- a/projects/ngx-avatar/package.json
+++ b/projects/ngx-avatar/package.json
@@ -19,7 +19,6 @@
   },
   "peerDependencies": {
     "@angular/common": "^6.0.0 || ^7.0.0",
-    "@angular/core": "^6.0.0 || ^7.0.0",
-    "@angular/http": "^6.0.0 || ^7.0.0"
+    "@angular/core": "^6.0.0 || ^7.0.0"
   }
 }

--- a/projects/ngx-avatar/src/lib/avatar.module.ts
+++ b/projects/ngx-avatar/src/lib/avatar.module.ts
@@ -1,6 +1,5 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { HttpClientModule } from '@angular/common/http';
 
 import { AvatarComponent } from './avatar.component';
 import { SourceFactory } from './sources/source.factory';
@@ -10,7 +9,7 @@ import { AVATAR_CONFIG } from './avatar-config.token';
 import { AvatarConfigService } from './avatar-config.service';
 
 @NgModule({
-  imports: [CommonModule, HttpClientModule],
+  imports: [CommonModule],
   declarations: [AvatarComponent],
   providers: [SourceFactory, AvatarService, AvatarConfigService],
   exports: [AvatarComponent]

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
+import { HttpClientModule } from '@angular/common/http';
 
 import { AvatarModule } from 'ngx-avatar';
 
@@ -12,6 +13,7 @@ const avatarColors = ['#FFB6C1', '#2c3e50', '#95a5a6', '#f39c12', '#1abc9c'];
   declarations: [AppComponent],
   imports: [
     BrowserModule,
+    HttpClientModule,
     //AvatarModule,
     AvatarModule.forRoot({
       colors: avatarColors


### PR DESCRIPTION
Stop importing HttpClientModule to prevent multiple instances of the HTTP client in the angular injector system.

closes #58