### PR TITLE
refactor: prevent deep import

### DIFF
--- a/projects/ngx-avatar/src/lib/sources/gravatar.ts
+++ b/projects/ngx-avatar/src/lib/sources/gravatar.ts
@@ -1,5 +1,5 @@
 import isRetina from 'is-retina';
-import { Md5 } from 'ts-md5/dist/md5';
+import { Md5 } from 'ts-md5';
 
 import { Source } from './source';
 import { AvatarSource } from './avatar-source.enum';


### PR DESCRIPTION
When I enable Ivy to build, there is a deep import warning message.

```
WARNING in Entry point 'ngx-avatar' contains deep imports into '/Users/zackyang/work/tp-f2e/node_modules/ts-md5/dist/md5'. This is probably not a problem, but may cause the compilation of entry points to be out of order.
```