### PR TITLE
Feature/avatar cache

### DIFF
--- a/projects/ngx-avatar/src/lib/avatar.component.spec.ts
+++ b/projects/ngx-avatar/src/lib/avatar.component.spec.ts
@@ -6,17 +6,23 @@ import { AvatarService } from './avatar.service';
 import { By } from '@angular/platform-browser';
 import { SimpleChange } from '@angular/core';
 import { AvatarSource } from './sources/avatar-source.enum';
-import { of } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import { Source } from './sources/source';
 
 class AvatarServiceMock {
-  public fetchAvatar(avatarUrl: string) {
-    return of(true);
+  public fetchAvatar(avatarUrl: string): Observable<any> {
+    return avatarUrl === 'https://api.github.com/users/github-username' ?
+        of({
+          avatar_url: 'https://mocked.url/foo.jpg',
+        }) :
+        throwError(new Error('Mocked error for ' + avatarUrl));
   }
-  public compareSources(source1: AvatarSource, source2: AvatarSource) {
+
+  public compareSources(source1: AvatarSource, source2: AvatarSource): number {
     return 0;
   }
-  public isSource(source: string) {
+
+  public isSource(source: string): boolean {
     return true;
   }
 
@@ -24,11 +30,15 @@ class AvatarServiceMock {
     return true;
   }
 
-  public getRandomColor(avatarText: string) {
+  public getRandomColor(avatarText: string): string {
     return '';
   }
 
-  public sourceHasFailedBefore(source: Source) {
+  public markSourceAsFailed(source: Source): void {
+
+  }
+
+  public sourceHasFailedBefore(source: Source): boolean {
     return source.sourceType === AvatarSource.GRAVATAR;
   }
 }
@@ -46,14 +56,12 @@ describe('AvatarComponent', () => {
         { provide: AvatarService, useClass: AvatarServiceMock }
       ]
     }).compileComponents();
-  }));
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(AvatarComponent);
     component = fixture.componentInstance;
     avatarService = TestBed.inject(AvatarService);
     fixture.detectChanges();
-  });
+  }));
 
   it('should create', () => {
     expect(component).toBeTruthy();
@@ -61,8 +69,6 @@ describe('AvatarComponent', () => {
 
   describe('AvatarText', () => {
     it('should display the initials of the given value', () => {
-      spyOn(avatarService, 'isSource').and.returnValue(true);
-      spyOn(avatarService, 'isTextAvatar').and.returnValue(true);
       component.initials = 'John Doe';
       component.ngOnChanges({
         initials: new SimpleChange(null, 'John Doe', true)
@@ -78,8 +84,6 @@ describe('AvatarComponent', () => {
   });
 
   it('should not try again failed sources', () => {
-    spyOn(avatarService, 'isSource').and.returnValue(true);
-    spyOn(avatarService, 'isTextAvatar').and.returnValue(true);
     component.gravatar = 'invalid@example.com';
     component.initials = 'John Doe';
     component.ngOnChanges({
@@ -93,6 +97,23 @@ describe('AvatarComponent', () => {
         By.css('.avatar-container > div')
     );
     expect(avatarTextEl.nativeElement.textContent.trim()).toBe('JD');
+  });
+
+  it('should try next async source if first async source fails', () => {
+    spyOn(avatarService, 'isTextAvatar').and.returnValue(false);
+    component.google = 'invalid@example.com';
+    component.github = 'github-username';
+    component.ngOnChanges({
+      google: new SimpleChange(null, 'invalid@example.com', true),
+      github: new SimpleChange(null, 'github-username', true)
+    });
+
+    fixture.detectChanges();
+
+    const avatarImgEl = fixture.debugElement.query(
+        By.css('.avatar-container > img')
+    );
+    expect(avatarImgEl.nativeElement.src).toBe('https://mocked.url/foo.jpg&s=50');
   });
 
   describe('AvatarImage', () => {});

--- a/projects/ngx-avatar/src/lib/avatar.component.spec.ts
+++ b/projects/ngx-avatar/src/lib/avatar.component.spec.ts
@@ -7,9 +7,10 @@ import { By } from '@angular/platform-browser';
 import { SimpleChange } from '@angular/core';
 import { AvatarSource } from './sources/avatar-source.enum';
 import { of } from 'rxjs';
+import { Source } from './sources/source';
 
 class AvatarServiceMock {
-  public fetchAvatar(source: string) {
+  public fetchAvatar(avatarUrl: string) {
     return of(true);
   }
   public compareSources(source1: AvatarSource, source2: AvatarSource) {
@@ -19,12 +20,16 @@ class AvatarServiceMock {
     return true;
   }
 
-  public isTextAvatar(source: string) {
+  public isTextAvatar(sourceType: AvatarSource) {
     return true;
   }
 
-  public getRandomColor(source: string) {
+  public getRandomColor(avatarText: string) {
     return '';
+  }
+
+  public sourceHasFailedBefore(source: Source) {
+    return source.sourceType === AvatarSource.GRAVATAR;
   }
 }
 
@@ -46,7 +51,7 @@ describe('AvatarComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(AvatarComponent);
     component = fixture.componentInstance;
-    avatarService = TestBed.get(AvatarService);
+    avatarService = TestBed.inject(AvatarService);
     fixture.detectChanges();
   });
 
@@ -70,6 +75,24 @@ describe('AvatarComponent', () => {
       );
       expect(avatarTextEl.nativeElement.textContent.trim()).toBe('JD');
     });
+  });
+
+  it('should not try again failed sources', () => {
+    spyOn(avatarService, 'isSource').and.returnValue(true);
+    spyOn(avatarService, 'isTextAvatar').and.returnValue(true);
+    component.gravatar = 'invalid@example.com';
+    component.initials = 'John Doe';
+    component.ngOnChanges({
+      gravatar: new SimpleChange(null, 'invalid@example.com', true),
+      initials: new SimpleChange(null, 'John Doe', true)
+    });
+
+    fixture.detectChanges();
+
+    const avatarTextEl = fixture.debugElement.query(
+        By.css('.avatar-container > div')
+    );
+    expect(avatarTextEl.nativeElement.textContent.trim()).toBe('JD');
   });
 
   describe('AvatarImage', () => {});

--- a/projects/ngx-avatar/src/lib/avatar.component.ts
+++ b/projects/ngx-avatar/src/lib/avatar.component.ts
@@ -308,9 +308,6 @@ export class AvatarComponent implements OnChanges, OnDestroy {
    * param sourceType avatar source type e.g facebook,twitter, etc.
    */
   private removeSource(sourceType: AvatarSource): void {
-    const index = this.sources.findIndex(source => source.sourceType === sourceType);
-    if (index !== -1) {
-      this.sources.splice(index, 1);
-    }
+    this.sources = this.sources.filter(source => source.sourceType !== sourceType);
   }
 }

--- a/projects/ngx-avatar/src/lib/avatar.component.ts
+++ b/projects/ngx-avatar/src/lib/avatar.component.ts
@@ -280,7 +280,7 @@ export class AvatarComponent implements OnChanges, OnDestroy {
         .subscribe(
             avatarSrc => (this.avatarSrc = avatarSrc),
             err => {
-              this.avatarService.markSourceAsFailed(source);
+              this.fetchAvatarSource();
             },
         );
   }

--- a/projects/ngx-avatar/src/lib/avatar.component.ts
+++ b/projects/ngx-avatar/src/lib/avatar.component.ts
@@ -292,15 +292,13 @@ export class AvatarComponent implements OnChanges, OnDestroy {
    * param sourceValue  source value e.g facebookId value, etc.
    */
   private addSource(sourceType: AvatarSource, sourceValue: string): void {
-    if (!this.isSourceExist(sourceType)) {
-      this.sources.push(
-        this.sourceFactory.newInstance(sourceType, sourceValue)
-      );
+    const source = this.sources.find(s => s.sourceType === sourceType);
+    if (source) {
+      source.sourceId = sourceValue;
     } else {
-      const index = this.sources.findIndex(
-        source => source.sourceType === sourceType
+      this.sources.push(
+          this.sourceFactory.newInstance(sourceType, sourceValue),
       );
-      this.sources[index].sourceId = sourceValue;
     }
   }
 
@@ -310,15 +308,9 @@ export class AvatarComponent implements OnChanges, OnDestroy {
    * param sourceType avatar source type e.g facebook,twitter, etc.
    */
   private removeSource(sourceType: AvatarSource): void {
-    if (this.isSourceExist(sourceType)) {
-      const index = this.sources.findIndex(
-        source => source.sourceType === sourceType
-      );
+    const index = this.sources.findIndex(source => source.sourceType === sourceType);
+    if (index !== -1) {
       this.sources.splice(index, 1);
     }
-  }
-
-  private isSourceExist(avatarSource: AvatarSource): boolean {
-    return this.sources.some(source => source.sourceType === avatarSource);
   }
 }

--- a/projects/ngx-avatar/src/lib/avatar.service.spec.ts
+++ b/projects/ngx-avatar/src/lib/avatar.service.spec.ts
@@ -7,6 +7,7 @@ import {
 import { AvatarService, defaultSources, defaultColors } from './avatar.service';
 import { AvatarSource } from './sources/avatar-source.enum';
 import { AvatarConfigService } from './avatar-config.service';
+import { Gravatar } from './sources/gravatar';
 
 const avatarServiceCongigSpy = {
   getAvatarSources: jasmine
@@ -31,8 +32,8 @@ describe('AvatarService', () => {
         ]
       });
 
-      avatarService = TestBed.get(AvatarService);
-      httpMock = TestBed.get(HttpTestingController);
+      avatarService = TestBed.inject(AvatarService);
+      httpMock = TestBed.inject(HttpTestingController);
     });
 
     afterEach(() => {
@@ -108,7 +109,7 @@ describe('AvatarService', () => {
     describe('compareSources', () => {
       it('should return a negative value when the first avatar type comes after the second one', () => {
         expect(
-          avatarService.copmareSources(
+          avatarService.compareSources(
             AvatarSource.FACEBOOK,
             AvatarSource.GOOGLE
           )
@@ -117,7 +118,7 @@ describe('AvatarService', () => {
 
       it('should return a positive value when the first avatar type comes before the second one', () => {
         expect(
-          avatarService.copmareSources(
+          avatarService.compareSources(
             AvatarSource.INITIALS,
             AvatarSource.FACEBOOK
           )
@@ -126,8 +127,28 @@ describe('AvatarService', () => {
 
       it('should return a zero value when the two give values are equales', () => {
         expect(
-          avatarService.copmareSources(AvatarSource.GITHUB, AvatarSource.GITHUB)
+          avatarService.compareSources(AvatarSource.GITHUB, AvatarSource.GITHUB)
         ).toBe(0);
+      });
+
+      it('should be able to tell if a source has failed before', () => {
+          const source1 = new Gravatar('source1');
+          const source1bis = new Gravatar('source1');
+          const source2 = new Gravatar('source2');
+
+          // At first nothing has failed
+          expect(avatarService.sourceHasFailedBefore(source1)).toBe(false);
+          expect(avatarService.sourceHasFailedBefore(source1bis)).toBe(false);
+          expect(avatarService.sourceHasFailedBefore(source2)).toBe(false);
+
+          avatarService.markSourceAsFailed(source1);
+
+          // source1 has failed, and source1bis should also be considered failed so
+          // we don't load the same avatar with failure from two component instances.
+          // source2 is still not failed, even though it is the same type of avatar
+          expect(avatarService.sourceHasFailedBefore(source1)).toBe(true);
+          expect(avatarService.sourceHasFailedBefore(source1bis)).toBe(true);
+          expect(avatarService.sourceHasFailedBefore(source2)).toBe(false);
       });
     });
   });

--- a/projects/ngx-avatar/src/lib/avatar.service.ts
+++ b/projects/ngx-avatar/src/lib/avatar.service.ts
@@ -84,16 +84,16 @@ export class AvatarService {
     return [AvatarSource.INITIALS, AvatarSource.VALUE].includes(sourceType);
   }
 
-  private getKey(source: Source): string {
+  private buildSourceKey(source: Source): string {
     return source.sourceType + '-' + source.sourceId;
   }
 
   public sourceHasFailedBefore(source: Source): boolean {
-    return this.failedSources.has(this.getKey(source));
+    return this.failedSources.has(this.buildSourceKey(source));
   }
 
   public markSourceAsFailed(source: Source): void {
-    this.failedSources.set(this.getKey(source), source);
+    this.failedSources.set(this.buildSourceKey(source), source);
   }
 
   private overrideAvatarSources(): void {

--- a/projects/ngx-avatar/src/lib/avatar.service.ts
+++ b/projects/ngx-avatar/src/lib/avatar.service.ts
@@ -5,6 +5,7 @@ import { Observable } from 'rxjs';
 
 import { AvatarConfigService } from './avatar-config.service';
 import { AvatarSource } from './sources/avatar-source.enum';
+import { Source } from './sources/source';
 
 /**
  * list of Supported avatar sources
@@ -44,6 +45,8 @@ export class AvatarService {
   public avatarSources: AvatarSource[] = defaultSources;
   public avatarColors: string[] = defaultColors;
 
+  private readonly failedSources = new Map<string, Source>();
+
   constructor(
     private http: HttpClient,
     private avatarConfigService: AvatarConfigService
@@ -64,7 +67,7 @@ export class AvatarService {
     return this.avatarColors[asciiCodeSum % this.avatarColors.length];
   }
 
-  public copmareSources(
+  public compareSources(
     sourceType1: AvatarSource,
     sourceType2: AvatarSource
   ): number {
@@ -79,6 +82,18 @@ export class AvatarService {
 
   public isTextAvatar(sourceType: AvatarSource): boolean {
     return [AvatarSource.INITIALS, AvatarSource.VALUE].includes(sourceType);
+  }
+
+  private getKey(source: Source): string {
+    return source.sourceType + '-' + source.sourceId;
+  }
+
+  public sourceHasFailedBefore(source: Source): boolean {
+    return this.failedSources.has(this.getKey(source));
+  }
+
+  public markSourceAsFailed(source: Source): void {
+    this.failedSources.set(this.getKey(source), source);
   }
 
   private overrideAvatarSources(): void {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -45,6 +45,14 @@
 
 <ngx-avatar [style]="customStyle" size="100" [name]="userName" [facebookId]="userFB" ></ngx-avatar>
 
+<h2>Failed sources are not retried</h2>
+
+<button (click)="failedSources.push(failedSources.length)">Add 1 more failing source</button>
+
+<span *ngFor="let i of failedSources">
+    <ngx-avatar [name]="'failing'" gravatarId="invalid@example.com"></ngx-avatar>
+</span>
+
 </div>
 
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -5,7 +5,7 @@
 <ngx-avatar googleId="103055244388830425867" [round]="false" size="70"></ngx-avatar>
 <ngx-avatar twitterId="StevenWilsonHQ" size="70"></ngx-avatar>
 <ngx-avatar vkontakteId="210700286" [round]="false" size="70"></ngx-avatar>
-<ngx-avatar size="100" githubId="sweko" size="70" ></ngx-avatar>
+<ngx-avatar githubId="sweko" size="70"></ngx-avatar>
 
 <!-- use facebook as avatar source, if it fails, it will use twitter -->
 <ngx-avatar facebookId="15349439434" twitterId="StevenWilsonHQ" size="70"></ngx-avatar>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -47,12 +47,11 @@
 
 <h2>Failed sources are not retried</h2>
 
-<button (click)="failedSources.push(failedSources.length)">Add 1 more failing source</button>
+<button (click)="failedSources.push(failedSources.length)">Add 1 failing source</button>
 
 <span *ngFor="let i of failedSources">
     <ngx-avatar [name]="'failing'" gravatarId="invalid@example.com"></ngx-avatar>
 </span>
 
 </div>
-
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -17,7 +17,8 @@ export class AppComponent implements OnInit {
     cursor: 'pointer'
   };
 
-  public failedSources: number[] = [];
+  failedSources: number[] = [];
+  
   constructor(public userService: UserService) {}
 
   ngOnInit() {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -17,6 +17,7 @@ export class AppComponent implements OnInit {
     cursor: 'pointer'
   };
 
+  public failedSources: number[] = [];
   constructor(public userService: UserService) {}
 
   ngOnInit() {


### PR DESCRIPTION
This is a new attempt to fix #25, loosely based on #59. Ideally it should be merged after #94, but let me know if you rather have this rebased on master instead.

Once an avatar source has failed, it will not be tried again until
a new instance of `AvatarService` is created (typically on page reload).
This avoids repeating the same errors again and again when navigating
between pages in a SPA where a user does not have an available profile
picture (eg: gravatar return 404).

The cache is on a per service and per ID basis. So it is possible to have
some users with working avatar from gravatar, while other users will
try once, fail, and then always fallback on initial avatar instead of gravatar.
