### PR TITLE
Explicitly support `null` as source value

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ $ ng serve
 | `src`         | *string \| null* |         | Fallback image to use                                                                                  |
 | `name`        | *string \| null* |         | Will be used to generate avatar based on the initials of the person                                    |
 | `value`       | *string \| null* |         | Show a value as avatar                                                                                 |
-| `initialsSize`| *number*         | 0       | Restricts the size of initials - it goes along with the name property and can be used to fix the number of characters that will be displayed as initials. 0 means not restrictions. |
+| `initialsSize`| *number*         | 0       | Restricts the size of initials - it goes along with the name property and can be used to fix the number of characters that will be displayed as initials. The `0` means no restrictions. |
 | `bgColor`     | *string*         | random  | Give the background a fixed color with a hex like for example #FF0000                                  |
 | `fgColor`     | *string*         | #FFF    | Give the text a fixed color with a hex like for example #FF0000                                        |
 | `size`        | *number*         | 50      | Size of the avatar                                                                                     |

--- a/README.md
+++ b/README.md
@@ -122,28 +122,28 @@ $ ng serve
 
 ## Options
 
-|   Attribute   |      Type      | Default |                                              Description                                               |
-| ------------- | ----------------- | ------- | ------------------------------------------------------------------------------------------------------ |
-| `facebookId` | *string* |         | Facebook ID                                                                                                       |
-| `googleId` | *string* |         |  Google ID                                                                                                     |
-| `twitterId`   | *string*             |         | Twitter Handle                                                                                                       |
-| `vkontakteId`   | *string*             |         | VK ID|
-| `skypeId`    | *string*          |       |  Skype ID                                                                                                      |
-| `gravatarId`    | *string*          |         | email or md5 email related to gravatar                                                                                                  |
-| `githubId`    | *string*          |         | Github ID                                                                                      
-| `src`         | *string*          |         | Fallback image to use                                                                                  |
-| `name`        | *string*          |         | Will be used to generate avatar based on the initials of the person                                    |
-| `value`       | *string*          |         | Show a value as avatar                                                                                 |
-| `initialsSize`        | *number*          |   undefined      | Restricts the size of initials - it goes along with the name property and can be used to fix the number of characters that will be displayed as initials.  |
-| `bgColor`       | *string*          | random  | Give the background a fixed color with a hex like for example #FF0000 |
-| `fgColor`     | *string*          | #FFF  | Give the text a fixed color with a hex like for example #FF0000 |
-| `size`        | *number*             | 50      | Size of the avatar                                                                                     |
-| `textSizeRatio` | *number*             | 3      | For text based avatars the size of the text as a fragment of size (size / textSizeRatio)                                 |
-| `round`       | *boolean*            | true   | Round the avatar corners                                                                               |
-| `cornerRadius`       | *number*            | 0   | Square avatars can have rounded corners using this property                                                                              |
-| `borderColor`       | *string*            | undefined   | Add border with the given color. boder's default style is '1px solid borderColor'                                                                               |
-| `style`         | *object*          |         | Style that will be applied on the root element
-| `clickOnAvatar`         | *Output*          |         | Fired when the avatar is clicked. The component emits the source object that has been used to fetch the avatar.||
+|   Attribute   |      Type        | Default |                                              Description                                               |
+| ------------- | ---------------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| `facebookId`  | *string \| null* |         | Facebook ID                                                                                            |
+| `googleId`    | *string \| null* |         |  Google ID                                                                                             |
+| `twitterId`   | *string \| null* |         | Twitter Handle                                                                                         |
+| `vkontakteId` | *string \| null* |         | VK ID                                                                                                  |
+| `skypeId`     | *string \| null* |         |  Skype ID                                                                                              |
+| `gravatarId`  | *string \| null* |         | email or md5 email related to gravatar                                                                 |
+| `githubId`    | *string \| null* |         | Github ID                                                                                              |
+| `src`         | *string \| null* |         | Fallback image to use                                                                                  |
+| `name`        | *string \| null* |         | Will be used to generate avatar based on the initials of the person                                    |
+| `value`       | *string \| null* |         | Show a value as avatar                                                                                 |
+| `initialsSize`| *number*         | 0       | Restricts the size of initials - it goes along with the name property and can be used to fix the number of characters that will be displayed as initials. 0 means not restrictions. |
+| `bgColor`     | *string*         | random  | Give the background a fixed color with a hex like for example #FF0000                                  |
+| `fgColor`     | *string*         | #FFF    | Give the text a fixed color with a hex like for example #FF0000                                        |
+| `size`        | *number*         | 50      | Size of the avatar                                                                                     |
+| `textSizeRatio`| *number*        | 3       | For text based avatars the size of the text as a fragment of size (size / textSizeRatio)               |
+| `round`       | *boolean*        | true    | Round the avatar corners                                                                               |
+| `cornerRadius`| *number*         | 0       | Square avatars can have rounded corners using this property                                            |
+| `borderColor` | *string*         | undefined | Add border with the given color. boder's default style is '1px solid borderColor'                    |
+| `style`       | *object*         |         | Style that will be applied on the root element                                                         |
+| `clickOnAvatar`| *Output*        |         | Fired when the avatar is clicked. The component emits the source object that has been used to fetch the avatar.|
 
  The source object has the following properties:
  * sourceType : avatar source ( Facebook, twitter, etc)

--- a/projects/ngx-avatar/src/lib/avatar.component.ts
+++ b/projects/ngx-avatar/src/lib/avatar.component.ts
@@ -66,35 +66,35 @@ export class AvatarComponent implements OnChanges, OnDestroy {
   @Input()
   public textSizeRatio = 3;
   @Input()
-  public bgColor: string;
+  public bgColor: string | undefined;
   @Input()
   public fgColor = '#FFF';
   @Input()
-  public borderColor: string;
+  public borderColor: string | undefined;
   @Input()
   public style: any = {};
   @Input()
   public cornerRadius = 0;
   @Input('facebookId')
-  public facebook: string;
+  public facebook: string | null;
   @Input('twitterId')
-  public twitter: string;
+  public twitter: string | null;
   @Input('googleId')
-  public google: string;
+  public google: string | null;
   @Input('vkontakteId')
-  public vkontakte: string;
+  public vkontakte: string | null;
   @Input('skypeId')
-  public skype: string;
+  public skype: string | null;
   @Input('gravatarId')
-  public gravatar: string;
+  public gravatar: string | null;
   @Input('githubId')
-  public github: string;
+  public github: string | null;
   @Input('src')
-  public custom: string;
+  public custom: string | null;
   @Input('name')
-  public initials: string;
+  public initials: string | null;
   @Input('value')
-  public value: string;
+  public value: string | null;
   @Input('placeholder')
   public placeholder: string;
   @Input('initialsSize')
@@ -133,8 +133,8 @@ export class AvatarComponent implements OnChanges, OnDestroy {
     for (const propName in changes) {
       if (this.avatarService.isSource(propName)) {
         const sourceType = AvatarSource[propName.toUpperCase()];
-        if (changes[propName].currentValue) {
-          const currentValue = changes[propName].currentValue;
+        const currentValue = changes[propName].currentValue;
+        if (currentValue && typeof currentValue === 'string') {
           this.addSource(sourceType, currentValue);
         } else {
           this.removeSource(sourceType);


### PR DESCRIPTION
I thought a bit more about supporting null input, and now believe we should support null values. This is typically useful for emails used for gravatar. The absence of email would typically be a null and not an empty string, because empty string is not a valid email. So we should expect to receive null values.

Luckily the code was almost ready for that and changes are kept minimal.

A null value is accepted as input, but source objects will only be
created if value is a string. This allow us a flexible input while
keeping our code clean.