### PR TITLE
Avatars are always non-null

### DIFF
--- a/projects/ngx-avatar/src/lib/sources/custom.ts
+++ b/projects/ngx-avatar/src/lib/sources/custom.ts
@@ -10,7 +10,7 @@ export class Custom implements Source {
 
   constructor(public sourceId: string) {}
 
-  public getAvatar(): string | null {
+  public getAvatar(): string {
     return this.sourceId;
   }
 }

--- a/projects/ngx-avatar/src/lib/sources/facebook.ts
+++ b/projects/ngx-avatar/src/lib/sources/facebook.ts
@@ -10,7 +10,7 @@ export class Facebook implements Source {
 
   constructor(public sourceId: string) {}
 
-  public getAvatar(size: number): string | null {
+  public getAvatar(size: number): string {
     return (
       'https://graph.facebook.com/' +
       `${this.sourceId}/picture?width=${size}&height=${size}`

--- a/projects/ngx-avatar/src/lib/sources/gravatar.ts
+++ b/projects/ngx-avatar/src/lib/sources/gravatar.ts
@@ -18,7 +18,7 @@ export class Gravatar implements Source {
       : Md5.hashStr(value).toString();
   }
 
-  public getAvatar(size: number): string | null {
+  public getAvatar(size: number): string {
     const avatarSize = isRetina() ? size * 2 : size;
     return `https://secure.gravatar.com/avatar/${
       this.sourceId

--- a/projects/ngx-avatar/src/lib/sources/initials.ts
+++ b/projects/ngx-avatar/src/lib/sources/initials.ts
@@ -10,7 +10,7 @@ export class Initials implements Source {
 
   constructor(public sourceId: string) {}
 
-  public getAvatar(size: number): string | null {
+  public getAvatar(size: number): string {
     return this.getInitials(this.sourceId, size);
   }
 

--- a/projects/ngx-avatar/src/lib/sources/skype.ts
+++ b/projects/ngx-avatar/src/lib/sources/skype.ts
@@ -9,7 +9,7 @@ export class Skype implements Source {
 
   constructor(public sourceId: string) {}
 
-  public getAvatar(): string | null {
+  public getAvatar(): string {
     return `https://api.skype.com/users/${this.sourceId}/profile/avatar`;
   }
 }

--- a/projects/ngx-avatar/src/lib/sources/source.ts
+++ b/projects/ngx-avatar/src/lib/sources/source.ts
@@ -20,5 +20,5 @@ export interface Source {
    * Gets the avatar that usually is a URL, but,
    * for example it can also be a string of initials from the name.
    */
-  getAvatar(size: number): string | null;
+  getAvatar(size: number): string;
 }

--- a/projects/ngx-avatar/src/lib/sources/twitter.ts
+++ b/projects/ngx-avatar/src/lib/sources/twitter.ts
@@ -11,7 +11,7 @@ export class Twitter implements Source {
 
   constructor(public sourceId: string) {}
 
-  public getAvatar(size: number): string | null {
+  public getAvatar(size: number): string {
     const twitterImgSize = this.getImageSize(size);
     return `https://twitter.com/${
       this.sourceId

--- a/projects/ngx-avatar/src/lib/sources/value.ts
+++ b/projects/ngx-avatar/src/lib/sources/value.ts
@@ -10,7 +10,7 @@ export class Value implements Source {
 
   constructor(public sourceId: string) {}
 
-  public getAvatar(): string | null {
+  public getAvatar(): string {
     return this.sourceId;
   }
 }


### PR DESCRIPTION
All existing avatars are always returning a string, and we don't have any special handling if they would ever return null, so it makes sense to be explicit about this pre-existing contract.