### PR TITLE
Natively lazy load images when scrolling

### DIFF
--- a/projects/ngx-avatar/src/lib/avatar.component.ts
+++ b/projects/ngx-avatar/src/lib/avatar.component.ts
@@ -48,6 +48,7 @@ import { takeWhile, map } from 'rxjs/operators';
         [ngStyle]="avatarStyle"
         (error)="fetchAvatarSource()"
         class="avatar-content"
+        loading="lazy"
       />
       <ng-template #textAvatar>
         <div *ngIf="avatarText" class="avatar-content" [ngStyle]="avatarStyle">


### PR DESCRIPTION
This enable native lazy loading of images when user scroll them into view,
as described in https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading

It is especially useful when we have a long list of users and their avatar.
Without this it would start anything between 10-100 http connections to
fetch images that are not visible on screen. With this patch we improve
performance of our app with very little effort and no downsides.