### PR TITLE
Adding ability to disable src cache

### DIFF
--- a/projects/ngx-avatar/src/lib/avatar-config.service.spec.ts
+++ b/projects/ngx-avatar/src/lib/avatar-config.service.spec.ts
@@ -1,7 +1,7 @@
 import { AvatarConfigService } from './avatar-config.service';
 import { AvatarSource } from './sources/avatar-source.enum';
 import { AvatarConfig } from './avatar-config';
-import { defaultSources, defaultColors } from './avatar.service';
+import { defaultSources, defaultColors, defaultDisableSrcCache } from './avatar.service';
 
 describe('AvatarConfigService', () => {
   describe('AvatarSources', () => {
@@ -101,6 +101,29 @@ describe('AvatarConfigService', () => {
 
       expect(avatarConfigService.getAvatarColors(defaultColors)).toBe(
         defaultColors
+      );
+    });
+  });
+
+  describe('AvatarDisableCache', () => {
+    it('should return the user\'s disable custom source cache settings when provided in the avatar configuration', () => {
+      const userDisableSrcCache = true;
+      const userConfig: AvatarConfig = {
+        disableSrcCache: userDisableSrcCache
+      };
+
+      const avatarConfigService = new AvatarConfigService(userConfig);
+
+      expect(avatarConfigService.getDisableSrcCache(defaultDisableSrcCache)).toBe(
+        userDisableSrcCache
+      );
+    });
+
+    it('should return the default disable custom source cache settings when no settings are provided in the avatar configuration', () => {
+      const avatarConfigService = new AvatarConfigService({});
+
+      expect(avatarConfigService.getDisableSrcCache(defaultDisableSrcCache)).toBe(
+        defaultDisableSrcCache
       );
     });
   });

--- a/projects/ngx-avatar/src/lib/avatar-config.service.ts
+++ b/projects/ngx-avatar/src/lib/avatar-config.service.ts
@@ -39,4 +39,9 @@ export class AvatarConfigService {
       defaultColors
     );
   }
+
+  public getDisableSrcCache(defaultDisableSrcCache: boolean): boolean {
+    if (this.userConfig.disableSrcCache === undefined) return defaultDisableSrcCache;
+    return this.userConfig.disableSrcCache;
+  }
 }

--- a/projects/ngx-avatar/src/lib/avatar-config.ts
+++ b/projects/ngx-avatar/src/lib/avatar-config.ts
@@ -13,4 +13,9 @@ export interface AvatarConfig {
    * The order in which the avatar sources will be used.
    */
   sourcePriorityOrder?: AvatarSource[];
+
+  /**
+   * Disable custom source (for custom images) cache.
+   */
+   disableSrcCache?: boolean;
 }

--- a/projects/ngx-avatar/src/lib/avatar.service.ts
+++ b/projects/ngx-avatar/src/lib/avatar.service.ts
@@ -39,6 +39,11 @@ export const defaultColors = [
 ];
 
 /**
+ * Default disable custom source cache settings
+ */
+export const defaultDisableSrcCache = false;
+
+/**
  * Provides utilities methods related to Avatar component
  */
 @Injectable()

--- a/projects/ngx-avatar/src/lib/sources/custom-no-cache.ts
+++ b/projects/ngx-avatar/src/lib/sources/custom-no-cache.ts
@@ -1,0 +1,18 @@
+import { Source } from './source';
+import { AvatarSource } from './avatar-source.enum';
+/**
+ *  Custom source implementation (with no cache).
+ *  return custom image as an avatar
+ *
+ */
+export class CustomNoCache implements Source {
+  readonly sourceType: AvatarSource = AvatarSource.CUSTOM;
+
+  constructor(public sourceId: string) {}
+
+  public getAvatar(): string {
+    const urlSuffix = Math.random();
+    const sourceId = `${this.sourceId}${this.sourceId.indexOf('?') > -1 ? '&' : '?'}_=${urlSuffix}`;
+    return sourceId;
+  }
+}

--- a/projects/ngx-avatar/src/lib/sources/source.factory.ts
+++ b/projects/ngx-avatar/src/lib/sources/source.factory.ts
@@ -13,6 +13,9 @@ import { Vkontakte } from './vkontakte';
 import { Github } from './github';
 import { SourceCreator } from './source.creator';
 import { AvatarSource } from './avatar-source.enum';
+import { AvatarConfigService } from '../avatar-config.service';
+import { defaultDisableSrcCache } from '../avatar.service';
+import { CustomNoCache } from './custom-no-cache';
 
 /**
  * Factory class that implements factory method pattern.
@@ -23,14 +26,16 @@ import { AvatarSource } from './avatar-source.enum';
 export class SourceFactory {
   private sources: { [key: string]: SourceCreator } = {};
 
-  constructor() {
+  constructor(avatarConfigService: AvatarConfigService) {
+    const disableSrcCache = avatarConfigService.getDisableSrcCache(defaultDisableSrcCache);
+
     this.sources[AvatarSource.FACEBOOK] = Facebook;
     this.sources[AvatarSource.TWITTER] = Twitter;
     this.sources[AvatarSource.GOOGLE] = Google;
     this.sources[AvatarSource.INSTAGRAM] = Instagram;
     this.sources[AvatarSource.SKYPE] = Skype;
     this.sources[AvatarSource.GRAVATAR] = Gravatar;
-    this.sources[AvatarSource.CUSTOM] = Custom;
+    this.sources[AvatarSource.CUSTOM] = disableSrcCache ? CustomNoCache : Custom;
     this.sources[AvatarSource.INITIALS] = Initials;
     this.sources[AvatarSource.VALUE] = Value;
     this.sources[AvatarSource.VKONTAKTE] = Vkontakte;


### PR DESCRIPTION
Adding ability to disable src cache based on the #123 

You can set the disable cache from the root config, it will work for all custom image avatars.
````
AvatarModule.forRoot({
  colors: avatarColors,
  disableSrcCache: true
})
````
It will add `Math.random()` to end of the image urls when set to true.
![console](https://user-images.githubusercontent.com/2902102/118177962-01998900-b3f9-11eb-840a-a050f84241ae.PNG)

Added new tests
![tests](https://user-images.githubusercontent.com/2902102/118178047-1aa23a00-b3f9-11eb-8c5a-0c21a9d1f0e5.PNG)